### PR TITLE
Build Mesa before generating rootfs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,8 @@ script:
 - "./scripts/download-gcc > /dev/null"
 - "./scripts/download-rootfs > /dev/null"
 - "./scripts/prepare-rootfs > /dev/null"
-- "./scripts/generate-rootfs > /dev/null"
 - "./scripts/build-mesa > /dev/null"
+- "./scripts/generate-rootfs > /dev/null"
 deploy:
   provider: releases
   api_key:


### PR DESCRIPTION
Mesa should now be custom built in Rootfs with renderonly Patch,
Weston should work with GPU